### PR TITLE
Update docs/tests for referendum election type

### DIFF
--- a/tests/test_id_builder.py
+++ b/tests/test_id_builder.py
@@ -198,6 +198,73 @@ class TestIdBuilder(TestCase):
             id.ids,
         )
 
+    def test_ref_with_subtype(self):
+        with self.assertRaises(ValueError):
+            IdBuilder("ref", date(2018, 5, 3)).with_subtype("x")
+
+    def test_ref_no_org_with_div(self):
+        id = IdBuilder("ref", date(2018, 5, 3)).with_division("test-division")
+        with self.assertRaises(ValueError):
+            id.election_group_id
+        with self.assertRaises(ValueError):
+            id.subtype_group_id
+        with self.assertRaises(ValueError):
+            id.organisation_group_id
+        with self.assertRaises(ValueError):
+            id.ballot_id
+        self.assertEqual([], id.ids)
+
+    def test_ref_no_org_no_div(self):
+        id = IdBuilder("ref", date(2018, 5, 3))
+        election_id = id.election_group_id
+        self.assertEqual("ref.2018-05-03", election_id)
+        with self.assertRaises(ValueError):
+            id.subtype_group_id
+        with self.assertRaises(ValueError):
+            id.organisation_group_id
+        with self.assertRaises(ValueError):
+            id.ballot_id
+        self.assertEqual(["ref.2018-05-03"], id.ids)
+
+    def test_ref_with_org_no_div(self):
+        id = IdBuilder("ref", date(2018, 5, 3)).with_organisation("test-org")
+        election_id = id.election_group_id
+        self.assertEqual("ref.2018-05-03", election_id)
+        with self.assertRaises(ValueError):
+            id.subtype_group_id
+        organisation_id = id.organisation_group_id
+        self.assertEqual("ref.test-org.2018-05-03", organisation_id)
+        with self.assertRaises(ValueError):
+            id.ballot_id
+        self.assertEqual(["ref.2018-05-03", "ref.test-org.2018-05-03"], id.ids)
+
+    def test_ref_with_org_with_div(self):
+        id = (
+            IdBuilder("ref", date(2018, 5, 3))
+            .with_organisation("test-org")
+            .with_division("test-division")
+        )
+        election_id = id.election_group_id
+        self.assertEqual("ref.2018-05-03", election_id)
+        with self.assertRaises(ValueError):
+            id.subtype_group_id
+        organisation_id = id.organisation_group_id
+        self.assertEqual("ref.test-org.2018-05-03", organisation_id)
+        ballot_id = id.ballot_id
+        self.assertEqual("ref.test-org.test-division.2018-05-03", ballot_id)
+        self.assertEqual(
+            [
+                "ref.2018-05-03",
+                "ref.test-org.2018-05-03",
+                "ref.test-org.test-division.2018-05-03",
+            ],
+            id.ids,
+        )
+
+    def test_ref_with_org_with_by_contest_type(self):
+        with self.assertRaises(ValueError):
+            IdBuilder("ref", date(2018, 5, 3)).with_contest_type("by")
+
     def test_pcc_mayor_with_subtype(self):
         for election_type in ("pcc", "mayor"):
             with self.assertRaises(ValueError):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -35,6 +35,8 @@ class TestValidator(TestCase):
         self.assertTrue(validate("europarl.2014-05-22"))
         self.assertTrue(validate("europarl.uk-wales.2014-05-22"))
         self.assertTrue(validate("ref.croydon.2021-10-07"))
+        self.assertTrue(validate("ref.croydon.some-division.2021-10-07"))
+        self.assertTrue(validate("ref.2021-10-07"))
 
     def test_invalid_ids(self):
         self.assertFalse(validate(7))  # not string
@@ -55,6 +57,9 @@ class TestValidator(TestCase):
             validate("gla.r.barnet-and-camden.2016-05-05")
         )  # invalid subtype
         self.assertFalse(validate("naw.x.2019-01-01"))  # invalid subtype
+        self.assertFalse(
+            validate("ref.croydon.by.2021-10-07")
+        )  # there is no such thing as a by-referendum
         # too many clauses
         self.assertFalse(validate("naw.r.mid-and-west-wales.something-else.2016-05-05"))
         self.assertFalse(validate("sp.c.shetland-islands.something-else.2019-08-29"))
@@ -69,3 +74,6 @@ class TestValidator(TestCase):
         self.assertFalse(validate("pcc.northumbria.something-else.2019-07-18"))
         self.assertFalse(validate("gla.c.barnet-and-camden.something-else.2016-05-05"))
         self.assertFalse(validate("europarl.uk-wales.something-else.2014-05-22"))
+        self.assertFalse(
+            validate("ref.croydon.some-division.something-else.2021-10-07")
+        )

--- a/uk_election_ids/election_ids.py
+++ b/uk_election_ids/election_ids.py
@@ -79,7 +79,7 @@ class IdBuilder:
 
         Args:
             election_type (str): May be one of
-                ``['europarl', 'gla', 'local', 'mayor', 'naw', 'nia', 'parl', 'pcc', 'sp', 'senedd']``
+                ``['europarl', 'gla', 'local', 'mayor', 'naw', 'nia', 'parl', 'pcc', 'sp', 'senedd', 'ref']``
             date (date|str): May be either a python date object,
                 or a string in 'Y-m-d' format.
                 ``myid = IdBuilder('local', date(2018, 5, 3))`` and

--- a/uk_election_ids/election_ids.py
+++ b/uk_election_ids/election_ids.py
@@ -187,6 +187,10 @@ class IdBuilder:
         """
         self._validate_contest_type(contest_type)
         if contest_type.lower() in ("by", "by election", "by-election"):
+            if self.election_type == "ref":
+                raise ValueError(
+                    "election_type %s may not have a by-election" % (self.election_type)
+                )
             self.contest_type = "by"
         return self
 


### PR DESCRIPTION
Had a quick play with the latest release. Following on from #4

- Add comprehensive test coverage for referendum election type
- Update the docs
- Don't allow by-referendums

ping @symroe or @michaeljcollinsuk for review

Side notes:

1. I've not bumped the version in setup.py or updated the changelog in this PR. I'll leave that with you.

2. I was also going to bump https://github.com/DemocracyClub/uk-election-ids/blob/fb148b86da91fc959c5ffa023f91e444a811339a/.travis.yml#L3-L8 to run the tests on python 3.9 while I was here but then I realised no tests are actually being run on pushes or PRs to this repo any more. Travis-ci.org is dead, need to migrate to a working CI service. I think you may have also been merrily tweaking builds that aren't running any tests in other recent PRs e.g: https://github.com/DemocracyClub/dc_signup_form/pull/12/files#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485 :laughing: