### PR TITLE
Add ID requirements matcher

### DIFF
--- a/tests/test_id_requirements.py
+++ b/tests/test_id_requirements.py
@@ -1,0 +1,105 @@
+import json
+from pathlib import Path
+from unittest import TestCase
+
+from uk_election_ids.metadata_tools import IDRequirementsMatcher
+
+
+class TestIDRequirementsJson(TestCase):
+    def test_defaults_valid_id_requirements(self):
+        id_requirements = json.load(
+            Path("uk_election_ids/data/id_requirements.json").open()
+        )
+
+        def iter_defaults(data: dict, parent=None):
+            default = data.get("default", "")
+            if default == "":
+                if not parent in ["dates", "nations"]:
+                    self.assertTrue(
+                        any([key in ["nations", "dates"] for key in data.keys()]),
+                        msg=f"{data} requires either a `default`, `nations` or `dates` key"
+                    )
+            for key, value in data.items():
+                if isinstance(value, dict):
+                    iter_defaults(value, parent=key)
+
+        for key, top_level_data in id_requirements["defaults"].items():
+            iter_defaults(top_level_data)
+
+
+class TestIDRequirementsMatcher(TestCase):
+    def test_matcher_england(self):
+        # Local election pre 2022 legislation
+        result = IDRequirementsMatcher("local.stroud.2022-05-04", nation="ENG")
+        assert result.get_id_requirements() is None
+
+        # Local election post 2022 legislation
+        result = IDRequirementsMatcher("local.stroud.2023-05-04", nation="ENG")
+        assert result.get_id_requirements() == "EA-2022"
+
+        # UK parliamentary election pre 2022 legislation
+        result = IDRequirementsMatcher("parl.2023-05-04", nation="ENG")
+        assert result.get_id_requirements() is None
+
+        # UK parliamentary election post 2022 legislation
+        result = IDRequirementsMatcher("parl.2023-10-03", nation="ENG")
+        assert result.get_id_requirements() == "EA-2022"
+
+    def test_matcher_scotland(self):
+        # Local election pre 2022 legislation
+        result = IDRequirementsMatcher("local.stroud.2022-05-04", nation="SCT")
+        assert result.get_id_requirements() is None
+
+        # Local election post 2022 legislation
+        result = IDRequirementsMatcher("local.stroud.2023-05-04", nation="SCT")
+        assert result.get_id_requirements() is None
+
+        # UK parliamentary election post 2022 legislation
+        result = IDRequirementsMatcher("parl.2023-10-03", nation="SCT")
+        assert result.get_id_requirements() == "EA-2022"
+
+        # Scottish parliamentary election post 2022 legislation
+        result = IDRequirementsMatcher("sp.c.2023-10-03", nation="SCT")
+        assert result.get_id_requirements() is None
+
+    def test_matcher_wales(self):
+        # Local election pre 2022 legislation
+        result = IDRequirementsMatcher("local.stroud.2022-05-04", nation="WLS")
+        assert result.get_id_requirements() is None
+
+        # Local election post 2022 legislation
+        result = IDRequirementsMatcher("local.stroud.2023-05-04", nation="WLS")
+        assert result.get_id_requirements() is None
+
+        # UK parliamentary election post 2022 legislation
+        result = IDRequirementsMatcher("parl.2023-10-03", nation="WLS")
+        assert result.get_id_requirements() == "EA-2022"
+
+        # Senedd post 2022 legislation
+        result = IDRequirementsMatcher("senedd.r.2023-05-04", nation="WLS")
+        assert result.get_id_requirements() is None
+
+        # NAW election post 2022 legislation
+        result = IDRequirementsMatcher("naw.2023-05-04", nation="WLS")
+        assert result.get_id_requirements() is None
+
+        # PCC election post 2022 legislation
+        result = IDRequirementsMatcher("pcc.2023-05-04", nation="WLS")
+        assert result.get_id_requirements() == "EA-2022"
+
+    def test_matcher_ni(self):
+        # Paliamentary election pre 2022 legislation
+        result = IDRequirementsMatcher("parl.2022-05-04", nation="NIR")
+        assert result.get_id_requirements() == "EFA-2002"
+
+        # Parliamentary election post 2022 legislation
+        result = IDRequirementsMatcher("parl.2023-10-03", nation="NIR")
+        assert result.get_id_requirements() == "EFA-2002"
+
+        # Parliamentary election pre 2002 legislation
+        result = IDRequirementsMatcher("parl.2001-11-28", nation="NIR")
+        assert result.get_id_requirements() is None
+
+        # NIA election post 2002 legislation
+        result = IDRequirementsMatcher("nia.2002-11-28", nation="NIR")
+        assert result.get_id_requirements() == "EFA-2002"

--- a/tests/test_id_requirements.py
+++ b/tests/test_id_requirements.py
@@ -14,7 +14,7 @@ class TestIDRequirementsJson(TestCase):
         def iter_defaults(data: dict, parent=None):
             default = data.get("default", "")
             if default == "":
-                if not parent in ["dates", "nations"]:
+                if parent not in ["dates", "nations"]:
                     self.assertTrue(
                         any([key in ["nations", "dates"] for key in data.keys()]),
                         msg=f"{data} requires either a `default`, `nations` or `dates` key"
@@ -45,6 +45,10 @@ class TestIDRequirementsMatcher(TestCase):
         result = IDRequirementsMatcher("parl.2023-10-03", nation="ENG")
         assert result.get_id_requirements() == "EA-2022"
 
+        # UK parliamentary by-election post 2022 legislation
+        result = IDRequirementsMatcher("parl.stroud.by.2023-05-04", nation="ENG")
+        assert result.get_id_requirements() == "EA-2022"
+
     def test_matcher_scotland(self):
         # Local election pre 2022 legislation
         result = IDRequirementsMatcher("local.stroud.2022-05-04", nation="SCT")
@@ -61,6 +65,10 @@ class TestIDRequirementsMatcher(TestCase):
         # Scottish parliamentary election post 2022 legislation
         result = IDRequirementsMatcher("sp.c.2023-10-03", nation="SCT")
         assert result.get_id_requirements() is None
+
+        # UK parliamentary by-election post 2022 legislation
+        result = IDRequirementsMatcher("parl.stroud.by.2023-05-04", nation="SCT")
+        assert result.get_id_requirements() == "EA-2022"
 
     def test_matcher_wales(self):
         # Local election pre 2022 legislation
@@ -87,8 +95,12 @@ class TestIDRequirementsMatcher(TestCase):
         result = IDRequirementsMatcher("pcc.2023-05-04", nation="WLS")
         assert result.get_id_requirements() == "EA-2022"
 
+        # UK parliamentary by-election post 2022 legislation
+        result = IDRequirementsMatcher("parl.stroud.by.2023-05-04", nation="WLS")
+        assert result.get_id_requirements() == "EA-2022"
+
     def test_matcher_ni(self):
-        # Paliamentary election pre 2022 legislation
+        # Parliamentary election pre 2022 legislation
         result = IDRequirementsMatcher("parl.2022-05-04", nation="NIR")
         assert result.get_id_requirements() == "EFA-2002"
 
@@ -102,4 +114,8 @@ class TestIDRequirementsMatcher(TestCase):
 
         # NIA election post 2002 legislation
         result = IDRequirementsMatcher("nia.2002-11-28", nation="NIR")
+        assert result.get_id_requirements() == "EFA-2002"
+
+        # UK parliamentary by-election post 2022 legislation
+        result = IDRequirementsMatcher("parl.stroud.by.2023-05-04", nation="NIR")
         assert result.get_id_requirements() == "EFA-2002"

--- a/tests/test_id_requirements.py
+++ b/tests/test_id_requirements.py
@@ -49,6 +49,22 @@ class TestIDRequirementsMatcher(TestCase):
         result = IDRequirementsMatcher("parl.stroud.by.2023-05-04", nation="ENG")
         assert result.get_id_requirements() == "EA-2022"
 
+        # Local election on 2018 pilot scheme
+        result = IDRequirementsMatcher("local.woking.2018-05-03", nation="ENG")
+        assert result.get_id_requirements() == "pilot-2018"
+
+        # Local election not on 2018 pilot scheme
+        result = IDRequirementsMatcher("local.stroud.2018-05-03", nation="ENG")
+        assert result.get_id_requirements() is None
+
+        # Local election on 2019 pilot scheme
+        result = IDRequirementsMatcher("local.woking.2019-05-02", nation="ENG")
+        assert result.get_id_requirements() == "pilot-2019"
+
+        # Local election not on 2019 pilot scheme
+        result = IDRequirementsMatcher("local.stroud.2019-05-02", nation="ENG")
+        assert result.get_id_requirements() is None
+
     def test_matcher_scotland(self):
         # Local election pre 2022 legislation
         result = IDRequirementsMatcher("local.stroud.2022-05-04", nation="SCT")

--- a/tests/test_meta_data_matcher.py
+++ b/tests/test_meta_data_matcher.py
@@ -10,5 +10,8 @@ class TestMetaDataMatcher(TestCase):
         matcher = IDRequirementsMatcher("parl.stroud.by.2022-05-04", nation="ENG")
         assert matcher.match_id()[0] == "parl.*.by"
 
+        matcher = IDRequirementsMatcher("parl.reading.tilehurst.by.2022-05-04", nation="ENG")
+        assert matcher.match_id()[0] == "parl.*.by"
+
         matcher = IDRequirementsMatcher("nonsense.parl.stroud.by.2022-05-04", nation="ENG")
         assert matcher.match_id()[0] is None

--- a/tests/test_meta_data_matcher.py
+++ b/tests/test_meta_data_matcher.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+from uk_election_ids.metadata_tools import IDRequirementsMatcher
+
+
+class TestMetaDataMatcher(TestCase):
+    def test_meta_data_matcher_regex(self):
+        matcher = IDRequirementsMatcher("parl.corby.2022-05-04", nation="ENG")
+        assert matcher.match_id()[0] == "parl"
+
+        matcher = IDRequirementsMatcher("parl.stroud.by.2022-05-04", nation="ENG")
+        assert matcher.match_id()[0] == "parl.*.by"
+
+        matcher = IDRequirementsMatcher("nonsense.parl.stroud.by.2022-05-04", nation="ENG")
+        assert matcher.match_id()[0] is None

--- a/uk_election_ids/data/id_requirements.json
+++ b/uk_election_ids/data/id_requirements.json
@@ -8,6 +8,51 @@
     }
   },
   "defaults": {
+    "parl.*.by": {
+      "default": "EA-2022",
+      "nations": {
+        "NIR": {
+          "dates": {
+            ":2002-08-31": {
+              "default": null
+            },
+            "2002-09-01:": {
+              "default": "EFA-2002"
+            }
+          }
+        },
+        "SCT": {
+          "dates": {
+            ":2023-01-15": {
+              "default": null
+            },
+            "2023-01-16:": {
+              "default": "EA-2022"
+            }
+          }
+        },
+        "ENG": {
+          "dates": {
+            ":2023-01-15": {
+              "default": null
+            },
+            "2023-01-16:": {
+              "default": "EA-2022"
+            }
+          }
+        },
+        "WLS": {
+          "dates": {
+            ":2023-01-15": {
+              "default": null
+            },
+            "2023-01-16:": {
+              "default": "EA-2022"
+            }
+          }
+        }
+      }
+    },
     "local": {
       "nations": {
         "NIR": {

--- a/uk_election_ids/data/id_requirements.json
+++ b/uk_election_ids/data/id_requirements.json
@@ -1,0 +1,108 @@
+{
+  "id_type": {
+    "EFA-2002": {
+      "name": "Electoral Fraud (Northern Ireland) Act 2002"
+    },
+    "EA-2022": {
+      "name": "Elections Act 2022"
+    }
+  },
+  "defaults": {
+    "local": {
+      "nations": {
+        "NIR": {
+          "default": "EFA-2002",
+          "dates": {
+            ":2002-08-31": {
+              "default": null
+            },
+            "2002-09-01:": {
+              "default": "EFA-2002"
+            }
+          }
+        },
+        "SCT": {
+          "default": null
+        },
+        "ENG": {
+          "default": "EA-2022",
+          "dates": {
+            ":2023-01-15": {
+              "default": null
+            },
+            "2023-01-16:": {
+              "default": "EA-2022"
+            }
+          }
+        },
+        "WLS": {
+          "default": null
+        }
+      }
+    },
+    "parl": {
+      "default": "EA-2022",
+      "nations": {
+        "NIR": {
+          "dates": {
+            ":2002-08-31": {
+              "default": null
+            },
+            "2002-09-01:": {
+              "default": "EFA-2002"
+            }
+          }
+        }
+      },
+      "dates": {
+        ":2023-09-30": {
+          "default": null
+        },
+        "2023-10-01:": {
+          "default": "EA-2022"
+        }
+      }
+    },
+    "nia": {
+      "default": "EFA-2002"
+    },
+    "europarl": {
+      "default": null
+    },
+    "naw": {
+      "default": null
+    },
+    "senedd": {
+      "default": null
+    },
+    "sp.c": {
+      "default": null
+    },
+    "sp.r": {
+      "default": null
+    },
+    "gla.c": {
+      "default": "EA-2022"
+    },
+    "gla": {
+      "default": "EA-2022"
+    },
+    "pcc": {
+      "default": "EA-2022",
+      "dates": {
+        ":2023-01-15": {
+          "default": null
+        },
+        "2023-01-16:": {
+          "default": "EA-2022"
+        }
+      }
+    },
+    "mayor": {
+      "default": "EA-2022"
+    },
+    "ref": {
+      "default": null
+    }
+  }
+}

--- a/uk_election_ids/data/id_requirements.json
+++ b/uk_election_ids/data/id_requirements.json
@@ -5,6 +5,12 @@
     },
     "EA-2022": {
       "name": "Elections Act 2022"
+    },
+    "pilot-2018": {
+      "name": "2018 voter ID pilot scheme"
+    },
+    "pilot-2019": {
+      "name": "2018 voter ID pilot scheme"
     }
   },
   "defaults": {
@@ -52,6 +58,12 @@
           }
         }
       }
+    },
+    "local.(bromley|gosport|swindon|watford|woking).*.2018-05-03": {
+      "default": "pilot-2018"
+    },
+    "local.(braintree|broxtowe|craven|derby|mid-sussex|north-kesteven|north-west-leicestershire|pendle|watford|woking).*.2019-05-02": {
+      "default": "pilot-2019"
     },
     "local": {
       "nations": {

--- a/uk_election_ids/metadata_tools.py
+++ b/uk_election_ids/metadata_tools.py
@@ -31,13 +31,16 @@ class MetaDataMatcher:
         Allow use of our slightly modified patterns in the ID requirements json file
         by escaping operator literals and appending additional operators to patterns where needed.
 
-        In our use case, '.' should represent a string literal (not just a match any)
-        and '*' should represent any number of any character (not just a repeater)
+        In our use case, '*' represents 0-many wildcards and '.' represents a string literal.
+        Additionally, if wildcard is empty, regex needs reduced '.' literals .
 
-        e.g. 'parl.*.by' becomes the slightly more esoteric 'parl\..*\.by'
+        i.e. 'parl.*.by' becomes the slightly more esoteric 'parl(\..*)?\.by' where:
+        \. represents a literal '.', always present at the start of a wildcard
+        (\..*) captures a sequence of "[any characters]."
+        ? captures a group between 0-1 times
         """
-        id_part = id_part.replace(".", r"\.")  # full-stops converted to string literals
-        id_part = id_part.replace("*", ".*")  # asterisk uses "any number of any character" behaviour
+        id_part = id_part.replace("-", r"\-")  # prevent '-' from being interpreted as range indicator
+        id_part = id_part.replace(".*.", r"\.(.*\.)?")
         return id_part
 
     def match_id(self):

--- a/uk_election_ids/metadata_tools.py
+++ b/uk_election_ids/metadata_tools.py
@@ -13,9 +13,9 @@ class MetaDataMatcher:
     """
 
     def __init__(
-        self,
-        election_id: str,
-        nation: Optional[str] = None,
+            self,
+            election_id: str,
+            nation: Optional[str] = None,
     ) -> None:
 
         self.nation = nation
@@ -75,6 +75,27 @@ class VotingSystemMatcher(MetaDataMatcher):
 
         default = data.get("default", None)
         if not default:
+            required_keys = data.keys()
+            raise ValueError(f"{id_part} requires {' or '.join(required_keys)}")
+
+        return data["default"]
+
+
+class IDRequirementsMatcher(MetaDataMatcher):
+    path = Path(__file__).parent / "data" / "id_requirements.json"
+    DATA = json.load(path.open())
+
+    def get_id_requirements(self):
+        id_part, data = self.match_id()
+        if self.nation:
+            if self.nation in data.get("nations", {}):
+                data = data["nations"][self.nation]
+
+        if data.get("dates"):
+            data = self.match_dates(data["dates"])
+
+        default = data.get("default", "")
+        if default == "":
             required_keys = data.keys()
             raise ValueError(f"{id_part} requires {' or '.join(required_keys)}")
 


### PR DESCRIPTION
Given an election ID, this piece of work aims to return whether an election requires ID or not (and if so, under which legislation is this ID required).

As well as a basic use case, this also covers split lookups (e.g. `parl.*.by`) as well as specific cases for the 2018 and 2019 voter ID pilot schemes. 