### PR TITLE
Add missing dates for GLA and NIA ID requirements

### DIFF
--- a/tests/test_id_requirements.py
+++ b/tests/test_id_requirements.py
@@ -65,6 +65,14 @@ class TestIDRequirementsMatcher(TestCase):
         result = IDRequirementsMatcher("local.stroud.2019-05-02", nation="ENG")
         assert result.get_id_requirements() is None
 
+        # GLA pre-2022 legislation
+        result = IDRequirementsMatcher("gla.c.brent-and-harrow.2016-05-05", nation="ENG")
+        assert result.get_id_requirements() is None
+
+        # GLA post 2022 legislation
+        result = IDRequirementsMatcher("gla.c.brent-and-harrow.2023-05-04", nation="ENG")
+        assert result.get_id_requirements() == "EA-2022"
+
     def test_matcher_scotland(self):
         # Local election pre 2022 legislation
         result = IDRequirementsMatcher("local.stroud.2022-05-04", nation="SCT")
@@ -126,6 +134,10 @@ class TestIDRequirementsMatcher(TestCase):
 
         # Parliamentary election pre 2002 legislation
         result = IDRequirementsMatcher("parl.2001-11-28", nation="NIR")
+        assert result.get_id_requirements() is None
+
+        # NIA election pre 2002 legislation
+        result = IDRequirementsMatcher("nia.2001-11-28", nation="NIR")
         assert result.get_id_requirements() is None
 
         # NIA election post 2002 legislation

--- a/uk_election_ids/data/id_requirements.json
+++ b/uk_election_ids/data/id_requirements.json
@@ -121,7 +121,15 @@
       }
     },
     "nia": {
-      "default": "EFA-2002"
+      "default": "EFA-2002",
+      "dates": {
+            ":2002-08-31": {
+              "default": null
+            },
+            "2002-09-01:": {
+              "default": "EFA-2002"
+            }
+          }
     },
     "europarl": {
       "default": null
@@ -139,10 +147,26 @@
       "default": null
     },
     "gla.c": {
-      "default": "EA-2022"
+      "default": "EA-2022",
+      "dates": {
+        ":2023-01-15": {
+          "default": null
+        },
+        "2023-01-16:": {
+          "default": "EA-2022"
+        }
+      }
     },
     "gla": {
-      "default": "EA-2022"
+      "default": "EA-2022",
+      "dates": {
+        ":2023-01-15": {
+          "default": null
+        },
+        "2023-01-16:": {
+          "default": "EA-2022"
+        }
+      }
     },
     "pcc": {
       "default": "EA-2022",


### PR DESCRIPTION
Dates for NIA pre-2001 and GLA pre-2022 were being incorrectly reported as requiring ID. Dates have been added to the ID requirements json file to accurately represent the dates legislation kicked in for these, plus some tests.

```[tasklist]
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Tests have been added and/or updated
```
